### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/lambdachecker/samTemplateLambdaChecker.yaml
+++ b/lambdachecker/samTemplateLambdaChecker.yaml
@@ -52,7 +52,7 @@ Resources:
             Action: 
               - "lambda:InvokeFunction"
             Resource: !Ref SMSantispam.Version
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
         Enabled: false


### PR DESCRIPTION
CloudFormation templates in amazon-sagemaker-to-aws-lambda-pipeline-blogpost have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.